### PR TITLE
[FIXED JENKINS-35220] Correctly display the credentials

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecr/AmazonECSRegistryCredential.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecr/AmazonECSRegistryCredential.java
@@ -63,9 +63,19 @@ public class AmazonECSRegistryCredential extends BaseStandardCredentials impleme
     }
 
     public AmazonWebServicesCredentials getCredentials() {
-        List<AmazonWebServicesCredentials> c = CredentialsProvider.lookupCredentials(
+        List<AmazonWebServicesCredentials> credentials = CredentialsProvider.lookupCredentials(
                 AmazonWebServicesCredentials.class, Jenkins.getInstance(), ACL.SYSTEM, Collections.EMPTY_LIST);
-        return c.isEmpty() ? null : c.get(0);
+
+        if (credentials.isEmpty()) {
+            return null;
+        }
+
+        for (AmazonWebServicesCredentials awsCredentials : credentials) {
+            if (awsCredentials.getId().equals(this.credentialsId)) {
+                return awsCredentials;
+            }
+        }
+        return  null;
     }
 
     public String getDescription() {


### PR DESCRIPTION
To re-produce it:
1. Create two AWS credentials
2. For example, create a Docker Build and Publish plublish step and go to `	Registry credentials`.
3. You will find the same credential several times.

https://issues.jenkins-ci.org/browse/JENKINS-35220

@reviewbybees @ndeloof 