### PR TITLE
- New credential ID with Region Name

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecr/AmazonECSRegistryCredential.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecr/AmazonECSRegistryCredential.java
@@ -55,15 +55,15 @@ public class AmazonECSRegistryCredential extends BaseStandardCredentials impleme
 
     private final String credentialsId;
 
-    private transient final Region region;
+    private final Regions region;
 
     public AmazonECSRegistryCredential(@CheckForNull CredentialsScope scope, String credentialsId) {
         super(scope, "ecr:"+credentialsId, "Amazon ECR Registry");
         this.credentialsId = credentialsId;
-        region = Region.getRegion(Regions.US_EAST_1);
+        region = Regions.US_EAST_1;
     }
 
-    public AmazonECSRegistryCredential(@CheckForNull CredentialsScope scope, String credentialsId, Region region) {
+    public AmazonECSRegistryCredential(@CheckForNull CredentialsScope scope, String credentialsId, Regions region) {
         super(scope, "ecr:" + region.getName() + ":" + credentialsId, "Amazon ECR Registry");
         this.credentialsId = credentialsId;
         this.region = region;
@@ -100,7 +100,7 @@ public class AmazonECSRegistryCredential extends BaseStandardCredentials impleme
         if (credentials == null) throw new IllegalStateException("Invalid credentials");
 
         final AmazonECRClient client = new AmazonECRClient(credentials.getCredentials(), new ClientConfiguration());
-        client.setRegion(region);
+        client.setRegion(Region.getRegion(region));
 
         final GetAuthorizationTokenResult authorizationToken = client.getAuthorizationToken(new GetAuthorizationTokenRequest());
         final List<AuthorizationData> authorizationData = authorizationToken.getAuthorizationData();

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecr/AmazonECSRegistryCredential.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecr/AmazonECSRegistryCredential.java
@@ -55,7 +55,7 @@ public class AmazonECSRegistryCredential extends BaseStandardCredentials impleme
 
     private final String credentialsId;
 
-    private final Region region;
+    private transient final Region region;
 
     public AmazonECSRegistryCredential(@CheckForNull CredentialsScope scope, String credentialsId) {
         super(scope, "ecr:"+credentialsId, "Amazon ECR Registry");

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecr/AmazonECSRegistryCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecr/AmazonECSRegistryCredentialsProvider.java
@@ -73,7 +73,7 @@ public class AmazonECSRegistryCredentialsProvider extends CredentialsProvider {
                 derived.add((C) new AmazonECSRegistryCredential(
                     credentials.getScope(),
                     credentials.getId(),
-                    Region.getRegion(region)));
+                    region));
             }
         }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecr/AmazonECSRegistryCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecr/AmazonECSRegistryCredentialsProvider.java
@@ -25,6 +25,8 @@
 
 package com.cloudbees.jenkins.plugins.amazonecr;
 
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
@@ -60,12 +62,19 @@ public class AmazonECSRegistryCredentialsProvider extends CredentialsProvider {
         List<C> derived = Lists.newLinkedList();
 
         final List<AmazonWebServicesCredentials> list = lookupCredentials(AmazonWebServicesCredentials.class, itemGroup,
-                ACL.SYSTEM, Collections.EMPTY_LIST);
+            ACL.SYSTEM, Collections.EMPTY_LIST);
 
         for (AmazonWebServicesCredentials credentials : list) {
             derived.add((C) new AmazonECSRegistryCredential(
+                credentials.getScope(),
+                credentials.getId()));
+
+            for (Regions region : Regions.values()) {
+                derived.add((C) new AmazonECSRegistryCredential(
                     credentials.getScope(),
-                    credentials.getId()));
+                    credentials.getId(),
+                    Region.getRegion(region)));
+            }
         }
 
         return derived;


### PR DESCRIPTION
- New credential ID format encompassing the region  ID added, format is `ecr:REGION:CREDENTIAL-ID`, e.g. `ecr:us-east-1:my_aws_id`
- Still supports the old credential ID format: `ecr:a-credential-id`.