### PR TITLE
[JENKINS-44911] Upgrade Jenkins core and AWS plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Amazon+ECR</url>
 
   <properties>
-    <jenkins.version>1.642.1</jenkins.version>
+    <jenkins.version>2.32.1</jenkins.version>
     <java.level>7</java.level>
     <powermock.version>1.6.1</powermock.version>
   </properties>
@@ -109,12 +109,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.11.68.1</version>
+      <version>1.11.119</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>aws-credentials</artifactId>
-      <version>1.19</version>
+      <version>1.20</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecr/AmazonECSRegistryCredential.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecr/AmazonECSRegistryCredential.java
@@ -128,12 +128,17 @@ public class AmazonECSRegistryCredential extends BaseStandardCredentials impleme
         final AmazonECRClient client = factory.getAmazonECRClientWithProxy(credentials.getCredentials());
         client.setRegion(Region.getRegion(region));
 
-        final GetAuthorizationTokenResult authorizationToken = client.getAuthorizationToken(new GetAuthorizationTokenRequest());
+        GetAuthorizationTokenRequest request = new GetAuthorizationTokenRequest();
+        final GetAuthorizationTokenResult authorizationToken = client.getAuthorizationToken(request);
         final List<AuthorizationData> authorizationData = authorizationToken.getAuthorizationData();
         if (authorizationData == null || authorizationData.isEmpty()) {
-            throw new IllegalStateException("Failed to retreive authorization token for Amazon ECR");
+            throw new IllegalStateException("Failed to retrieve authorization token for Amazon ECR");
         }
-        LOG.fine("Success");
+        LOG.fine("Success ");
+        if(LOG.isLoggable(Level.ALL)){
+            LOG.finest("Auth token: " + authorizationToken.toString());
+            LOG.finest("Request: " + request.toString());
+        }
         return Secret.fromString(authorizationData.get(0).getAuthorizationToken());
     }
 


### PR DESCRIPTION
@reviewbybees 

Upgrade to the last versions of was Plugins, also upgrade the minimum Jenkins core supported it is difficult to support and test several versions of Jenkins Core and Pipeline versions, now it is only supported 2.32.1>
Jenkins core 2.32.1
aws-java-sdk 1.11.119
aws-credentials 1.20

log improvements to trace the token request