### PR TITLE
Update to 2.426.x baseline (+ cleanups)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,10 @@
-#!groovy
-def recentLTS = '2.414.2'
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
 buildPlugin(
-  // Container agents start faster and are easier to administer
-  useContainerAgent: true,
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux',   jdk: '21'],
-    [platform: 'windows', jdk: '17', jenkins: recentLTS],
-  ]
-)
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/amazon-ecr.svg?color=blue)](https://plugins.jenkins.io/amazon-ecr)
 [![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins%2Famazon-ecr-plugin%2Fmain)](https://ci.jenkins.io/job/Plugins/job/amazon-ecr-plugin/job/main/)
 [![GitHub license](https://img.shields.io/github/license/jenkinsci/amazon-ecr-plugin.svg)](https://github.com/jenkinsci/amazon-ecr-plugin/blob/main/LICENSE.txt)
-[![Maintenance](https://img.shields.io/maintenance/yes/2023.svg)]()
+[![Maintenance](https://img.shields.io/maintenance/yes/2024.svg)]()
 
 This plugin offers integration with [Amazon Container Registry
 (ECR)](https://aws.amazon.com/ecr/) as a [DockerRegistryToken] source to convert

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.74</version>
+    <version>4.83</version>
   </parent>
 
   <groupId>com.cloudbees.jenkins.plugins</groupId>
@@ -61,7 +61,7 @@
     <revision>1</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/amazon-ecr-plugin</gitHubRepo>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.426.3</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
 
@@ -69,8 +69,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
-        <version>2102.v854b_fec19c92</version>
+        <artifactId>bom-2.426.x</artifactId>
+        <version>3143.v347db_7c6db_6e</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -80,7 +80,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>aws-credentials</artifactId>
-      <version>191.vcb_f183ce58b_9</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -89,12 +88,10 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>docker-commons</artifactId>
-      <version>1.21</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
       <artifactId>aws-java-sdk-ecr</artifactId>
-      <version>1.12.287-357.vf82d85a_6eefd</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecr/AmazonECSRegistryCredential.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecr/AmazonECSRegistryCredential.java
@@ -39,15 +39,14 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.ItemGroup;
 import hudson.security.ACL;
 import hudson.util.Secret;
-import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 
@@ -66,13 +65,13 @@ public class AmazonECSRegistryCredential extends BaseStandardCredentials
     private final ItemGroup itemGroup;
 
     public AmazonECSRegistryCredential(
-            CredentialsScope scope, @Nonnull String credentialsId, String description, ItemGroup itemGroup) {
-        this(scope, credentialsId, Regions.US_EAST_1, description, (ItemGroup<?>) itemGroup);
+            CredentialsScope scope, @NonNull String credentialsId, String description, ItemGroup itemGroup) {
+        this(scope, credentialsId, Regions.US_EAST_1, description, itemGroup);
     }
 
     public AmazonECSRegistryCredential(
             @CheckForNull CredentialsScope scope,
-            @Nonnull String credentialsId,
+            @NonNull String credentialsId,
             Regions region,
             String description,
             ItemGroup itemGroup) {
@@ -88,7 +87,7 @@ public class AmazonECSRegistryCredential extends BaseStandardCredentials
         this.itemGroup = itemGroup;
     }
 
-    @Nonnull
+    @NonNull
     public String getCredentialsId() {
         return credentialsId;
     }
@@ -97,8 +96,8 @@ public class AmazonECSRegistryCredential extends BaseStandardCredentials
         LOG.log(Level.FINE, "Looking for Amazon web credentials ID: {0} Region: {1}", new Object[] {
             this.credentialsId, this.region
         });
-        List<AmazonWebServicesCredentials> credentials = CredentialsProvider.lookupCredentials(
-                AmazonWebServicesCredentials.class, itemGroup, ACL.SYSTEM, Collections.EMPTY_LIST);
+        List<AmazonWebServicesCredentials> credentials = CredentialsProvider.lookupCredentialsInItemGroup(
+                AmazonWebServicesCredentials.class, itemGroup, ACL.SYSTEM2);
 
         if (LOG.isLoggable(Level.FINEST)) {
             String fullStackTrace = org.apache.commons.lang.exception.ExceptionUtils.getStackTrace(new Throwable());
@@ -120,14 +119,15 @@ public class AmazonECSRegistryCredential extends BaseStandardCredentials
         return null;
     }
 
-    @Nonnull
+    @NonNull
+    @Override
     public String getDescription() {
         String description = super.getDescription();
         LOG.finest(description);
         return description;
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public Secret getPassword() {
         final AmazonWebServicesCredentials credentials = getCredentials();
@@ -167,13 +167,13 @@ public class AmazonECSRegistryCredential extends BaseStandardCredentials
         return Secret.fromString(authorizationData.get(0).getAuthorizationToken());
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public String getUsername() {
         return "AWS";
     }
 
-    @Nonnull
+    @NonNull
     public String getEmail() {
         return "nobody@example.com";
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecr/AmazonECSRegistryCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecr/AmazonECSRegistryCredentialsProvider.java
@@ -29,17 +29,17 @@ import com.amazonaws.regions.Regions;
 import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
 import hudson.model.ItemGroup;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import org.acegisecurity.Authentication;
+import org.springframework.security.core.Authentication;
 
 /**
  * This class automatically wraps existing {@link AmazonWebServicesCredentials} instances into a
@@ -50,19 +50,22 @@ public class AmazonECSRegistryCredentialsProvider extends CredentialsProvider {
 
     private static final Logger LOG = Logger.getLogger(AmazonECSRegistryCredentialsProvider.class.getName());
 
-    @Nonnull
+    @NonNull
     @Override
-    public <C extends Credentials> List<C> getCredentials(
-            @Nonnull Class<C> type, @Nullable ItemGroup itemGroup, @Nullable Authentication authentication) {
+    public <C extends Credentials> List<C> getCredentialsInItemGroup(
+            @NonNull Class<C> type,
+            @Nullable ItemGroup itemGroup,
+            @Nullable Authentication authentication,
+            @NonNull List<DomainRequirement> domainRequirements) {
 
         if (!type.isAssignableFrom(AmazonECSRegistryCredential.class)) {
-            return ImmutableList.of();
+            return Collections.emptyList();
         }
 
-        List<C> derived = Lists.newLinkedList();
+        List<C> derived = new LinkedList<>();
 
-        final List<AmazonWebServicesCredentials> list = lookupCredentials(
-                AmazonWebServicesCredentials.class, itemGroup, authentication, Collections.EMPTY_LIST);
+        final List<AmazonWebServicesCredentials> list = lookupCredentialsInItemGroup(
+                AmazonWebServicesCredentials.class, itemGroup, authentication, domainRequirements);
 
         for (AmazonWebServicesCredentials credentials : list) {
             LOG.log(


### PR DESCRIPTION
As a nice side-effect, this gets rid of remaining Guava usages.